### PR TITLE
Feature/41 jwt generate tokens

### DIFF
--- a/generateSecrets.js
+++ b/generateSecrets.js
@@ -38,7 +38,7 @@ function updateEnvContent(envContent, key, value) {
 envContent = updateEnvContent(envContent, 'JWT_ACCESS_SECRET', accessSecret);
 envContent = updateEnvContent(envContent, 'JWT_REFRESH_SECRET', refreshSecret);
 envContent = updateEnvContent(envContent, 'JWT_RESET_SECRET', resetSecret);
-envContent = updateEnvContent(envContent, 'JWT_CONFIRMATION_SECRET', confirmationSecret);
+envContent = updateEnvContent(envContent, 'JWT_CONFIRM_SECRET', confirmationSecret);  // изменено
 
 try {
   fs.writeFileSync(envFilePath, envContent, 'utf8');

--- a/generateSecrets.js
+++ b/generateSecrets.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const crypto = require('crypto');
+
+function generateSecret() {
+  return crypto.randomBytes(64).toString('base64'); 
+}
+
+const accessSecret = generateSecret();
+const refreshSecret = generateSecret();
+const resetSecret = generateSecret();
+const confirmationSecret = generateSecret();
+
+const envFilePath = '.env.local';
+let envContent = fs.existsSync(envFilePath) ? fs.readFileSync(envFilePath, 'utf8') : '';
+
+function updateEnvContent(envContent, key, value) {
+  const regex = new RegExp(`^${key}=.*`, 'm');
+  if (regex.test(envContent)) {
+    envContent = envContent.replace(regex, `${key}=${value}`);
+  } else {
+    envContent += `\n${key}=${value}`;
+  }
+  return envContent;
+}
+
+envContent = updateEnvContent(envContent, 'JWT_ACCESS_SECRET', accessSecret);
+envContent = updateEnvContent(envContent, 'JWT_REFRESH_SECRET', refreshSecret);
+envContent = updateEnvContent(envContent, 'JWT_RESET_SECRET', resetSecret);
+envContent = updateEnvContent(envContent, 'JWT_CONFIRMATION_SECRET', confirmationSecret);
+
+fs.writeFileSync(envFilePath, envContent, 'utf8');
+
+console.log('.env.local updated!');

--- a/generateSecrets.js
+++ b/generateSecrets.js
@@ -11,7 +11,19 @@ const resetSecret = generateSecret();
 const confirmationSecret = generateSecret();
 
 const envFilePath = '.env.local';
-let envContent = fs.existsSync(envFilePath) ? fs.readFileSync(envFilePath, 'utf8') : '';
+let envContent = '';
+
+try {
+  if (fs.existsSync(envFilePath)) {
+    envContent = fs.readFileSync(envFilePath, 'utf8');
+    console.log('Existing .env.local file found.');
+  } else {
+    console.log('No .env.local file found, will create a new one.');
+  }
+} catch (error) {
+  console.error(`Error reading ${envFilePath}: ${error.message}`);
+  process.exit(1);
+}
 
 function updateEnvContent(envContent, key, value) {
   const regex = new RegExp(`^${key}=.*`, 'm');
@@ -28,6 +40,11 @@ envContent = updateEnvContent(envContent, 'JWT_REFRESH_SECRET', refreshSecret);
 envContent = updateEnvContent(envContent, 'JWT_RESET_SECRET', resetSecret);
 envContent = updateEnvContent(envContent, 'JWT_CONFIRMATION_SECRET', confirmationSecret);
 
-fs.writeFileSync(envFilePath, envContent, 'utf8');
-
-console.log('.env.local updated!');
+try {
+  fs.writeFileSync(envFilePath, envContent, 'utf8');
+  console.log('.env.local updated successfully!');
+  console.log('JWT secrets have been generated and saved.');
+} catch (error) {
+  console.error(`Error writing to ${envFilePath}: ${error.message}`);
+  process.exit(1);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "cron": "^2.1.0",
+        "crypto": "^1.0.1",
         "dotenv": "^10.0.0",
         "email-templates": "^10.0.0",
         "express": "^4.17.1",
@@ -3996,6 +3997,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/css-select": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cron": "^2.1.0",
-    "crypto": "^1.0.1",
     "dotenv": "^10.0.0",
     "email-templates": "^10.0.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "cron": "^2.1.0",
+    "crypto": "^1.0.1",
     "dotenv": "^10.0.0",
     "email-templates": "^10.0.0",
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "nodemon src/app.js --legacy-watch",
     "lint": "eslint . --fix",
     "prepare": "husky install",
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "generate:secrets": "node generateSecrets.js"
   },
   "author": "SoftServe ITA",
   "license": "ISC",


### PR DESCRIPTION
A script has been created for automatically generating JWT secrets.

You can use the following command to generate them: 
1. node generateSecrets.js 
2. npm run generate:secrets

After running the command, the secrets will be automatically added to the file .env.local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated tool that securely generates cryptographic keys and updates local configuration settings.
  - Added a convenient command-line option to run the secret generation process, enhancing the developer workflow.
- **Bug Fixes**
  - Updated the `pre-commit` script for improved formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->