### PR TITLE
#63-search-case-insensitive

### DIFF
--- a/src/utils/getRegex.js
+++ b/src/utils/getRegex.js
@@ -1,5 +1,6 @@
 const getRegex = (regex = '') => ({
-  $regex: regex.length > 0 ? regex : '.*'
+  $regex: regex.length > 0 ? regex : '.*',
+  $options: 'i'
 })
 
 module.exports = getRegex


### PR DESCRIPTION
Make resource name search case-insensitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced regex matching to be case-insensitive throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->