### PR TITLE
Add subject model and swagger docs

### DIFF
--- a/docs/categories.yaml
+++ b/docs/categories.yaml
@@ -6,6 +6,10 @@ components:
         - name
         - appearance
       properties:
+        _id:
+          type: string
+          description: The unique identifier of the category
+          example: "60c72b2f5f9b2f1b32c87c2a"
         name:
           type: string
           example: "Design"
@@ -24,3 +28,13 @@ components:
               type: string
               example: "#66C42C"
               description: Color of the category icon. Defaults to '#66C42C'.
+        createdAt:
+          type: string
+          format: date-time
+          description: The time when the category was created
+          example: "2021-06-24T15:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: The last time the category was updated
+          example: "2021-06-24T16:00:00Z"

--- a/docs/subject.yaml
+++ b/docs/subject.yaml
@@ -1,0 +1,41 @@
+components:
+  schemas:
+    Subject:
+      type: object
+      required:
+        - name
+        - category
+      properties:
+        _id:
+          type: string
+          description: The unique identifier of the subject
+          example: "60c72b2f5f9b2f1b32c87c2a"
+        name:
+          type: string
+          description: The name of the subject
+          example: "Math"
+        category:
+          type: string
+          description: The category ID to which the subject belongs (references a category)
+          example: "60c72b2f5f9b2f1b32c87c2b"
+        totalOffers:
+          type: object
+          properties:
+            student:
+              type: integer
+              description: The number of offers available for students in this subject
+              example: 100
+            tutor:
+              type: integer
+              description: The number of offers available for tutors in this subject
+              example: 25
+        createdAt:
+          type: string
+          format: date-time
+          description: The time when the subject was created
+          example: "2021-06-24T15:00:00Z"
+        updatedAt:
+          type: string
+          format: date-time
+          description: The last time the subject was updated
+          example: "2021-06-24T16:00:00Z"

--- a/src/consts/models.js
+++ b/src/consts/models.js
@@ -13,7 +13,8 @@ const refs = {
   ATTACHMENT: 'Attachment',
   QUESTION: 'Question',
   RESOURCES_CATEGORY: 'ResourcesCategory',
-  CATEGORY: 'Category'
+  CATEGORY: 'Category',
+  SUBJECT: 'Subject'
 }
 
 module.exports = refs

--- a/src/models/subject.js
+++ b/src/models/subject.js
@@ -1,0 +1,35 @@
+const { Schema, model } = require('mongoose');
+const { SUBJECT } = require('~/consts/models');
+const { FIELD_CANNOT_BE_EMPTY } = require('~/consts/errors');
+const { CATEGORY } = require('~/consts/models');
+const subjectSchema = new Schema(
+  {
+    name: {
+      type: String,
+      required: [true, FIELD_CANNOT_BE_EMPTY('name')],
+      unique: true,
+      trim: true
+    },
+    category: {
+      type: Schema.Types.ObjectId,
+      ref: CATEGORY,
+      required: [true, FIELD_CANNOT_BE_EMPTY('category')]
+    },
+    totalOffers: {
+      student: {
+        type: Number,
+        default: 0
+      },
+      tutor: {
+        type: Number,
+        default: 0
+      }
+    }
+  },
+  {
+    timestamps: true, 
+    versionKey: false
+  }
+);
+
+module.exports = model(SUBJECT, subjectSchema);


### PR DESCRIPTION
Add subject model and swagger docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded API documentation for categories to include unique identifiers and timestamps.
  - Added comprehensive API documentation for subjects, detailing structure and example values.

- **New Features**
  - Introduced support for managing subjects, including a new subject model with fields for name, category, offer counts, and timestamps.

- **Chores**
  - Updated internal references to include the new subject entity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->