### PR TITLE
Сhange getNamesByCategoryId endpoint

### DIFF
--- a/docs/category.yaml
+++ b/docs/category.yaml
@@ -205,10 +205,19 @@ paths:
                   data:
                     type: array
                     items:
-                      $ref: '#/components/schemas/Subject'
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                          example: 680aba16c2b544ce98e8d35b
+                          description: Subject ID
+                        name:
+                          type: string
+                          example: JavaScript
+                          description: Subject name
                   total:
                     type: integer
-                    example: 2
+                    example: 1
                   page:
                     type: integer
                     example: 1

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -38,7 +38,7 @@ const categoryService = {
       Subject.find(query)
         .skip(skip)
         .limit(limit)
-        .select('name')
+        .select('id name')
         .lean()
         .exec(),
       Subject.countDocuments(query)
@@ -50,12 +50,8 @@ const categoryService = {
       throw error;
     }
   
-    const subjectNames = subjects.map(subject => ({
-      name: subject.name
-    }));
-  
     return {
-      data: subjectNames,
+      data: subjects,
       total,
       page,
       limit,


### PR DESCRIPTION
Add a id field to the query response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- The list of subject names for a category now correctly includes both the subject ID and name in the response.
- **Documentation**
	- Updated API documentation to reflect the new response format, showing both subject ID and name for each subject.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->