### PR TITLE
Add update subject endpoint

### DIFF
--- a/docs/subject.yaml
+++ b/docs/subject.yaml
@@ -147,27 +147,42 @@ paths:
                   _id:
                     type: string
                     description: The unique identifier of the subject
+                    example: 680ab9772c70938761edda5e
                   name:
                     type: string
                     description: The name of the subject
+                    example: JavaScript
                   category:
                     type: object
                     properties:
                       _id:
                         type: string
                         description: The ID of the category
+                        example: 680ab9772c70938761edda5e
                       name:
                         type: string
                         description: The name of the category
+                        example: IT
                       appearance:
                         type: object
                         properties:
                           icon:
                             type: string
                             description: The path to the category's icon
+                            example: icons/design.svg
                           color:
                             type: string
                             description: The color of the category in HEX format
+                            example: #FF5733
+                  totalOffers:
+                    type: object
+                    properties:
+                      student:
+                        type: integer
+                        description: Total student offers for the subject
+                      tutor:
+                        type: integer
+                        description: Total tutor offers for the subject
                   createdAt:
                     type: string
                     format: date-time
@@ -180,3 +195,96 @@ paths:
           description: Invalid subject ID format
         '404':
           description: Subject not found
+/subjects/{id}:
+  patch:
+    tags:
+      - Subjects
+    summary: Update a subject
+    description: This endpoint allows you to update an existing subject by its unique identifier. Only the `name` and `category` fields are allowed to be updated.
+    operationId: updateSubjectById
+    security:
+      - bearerAuth: []
+    parameters:
+      - in: path
+        name: id
+        required: true
+        description: The unique identifier of the subject
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: The new name of the subject
+                example: "Advanced JavaScript"
+              category:
+                type: string
+                description: The ID of the new category for the subject
+                example: 68081d3202a459c8915433c7
+            additionalProperties: false
+    responses:
+      '200':
+        description: Successful response — subject updated
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _id:
+                  type: string
+                  description: The unique identifier of the updated subject
+                  example: 680aba16c2b544ce98e8d35b
+                name:
+                  type: string
+                  description: The updated name of the subject
+                  example: Frontend
+                category:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      description: The ID of the category
+                      example: 680aba16c2b544ce98e8d35b
+                    name:
+                      type: string
+                      description: The name of the category
+                      example: IT
+                    appearance:
+                      type: object
+                      properties:
+                        icon:
+                          type: string
+                          description: The path to the category's icon
+                          example: icons/design.svg
+                        color:
+                          type: string
+                          description: The color of the category in HEX format
+                          example: #FF5733
+                totalOffers:
+                  type: object
+                  properties:
+                    student:
+                      type: integer
+                      description: Total student offers for the subject
+                    tutor:
+                      type: integer
+                      description: Total tutor offers for the subject
+                createdAt:
+                  type: string
+                  format: date-time
+                  description: The time the subject was created
+                updatedAt:
+                  type: string
+                  format: date-time
+                  description: The time the subject was last updated
+      '400':
+        description: Invalid subject or category ID format
+      '404':
+        description: Subject or category not found
+      '500':
+        description: Internal server error

--- a/docs/subject.yaml
+++ b/docs/subject.yaml
@@ -147,33 +147,33 @@ paths:
                   _id:
                     type: string
                     description: The unique identifier of the subject
-                    example: 680ab9772c70938761edda5e
+                    example: "680ab9772c70938761edda5e"
                   name:
                     type: string
                     description: The name of the subject
-                    example: JavaScript
+                    example: "JavaScript"
                   category:
                     type: object
                     properties:
                       _id:
                         type: string
                         description: The ID of the category
-                        example: 680ab9772c70938761edda5e
+                        example: "680ab9772c70938761edda5e"
                       name:
                         type: string
                         description: The name of the category
-                        example: IT
+                        example: "IT"
                       appearance:
                         type: object
                         properties:
                           icon:
                             type: string
                             description: The path to the category's icon
-                            example: icons/design.svg
+                            example: "icons/design.svg"
                           color:
                             type: string
                             description: The color of the category in HEX format
-                            example: #FF5733
+                            example: "#FF5733"
                   totalOffers:
                     type: object
                     properties:
@@ -225,7 +225,7 @@ paths:
               category:
                 type: string
                 description: The ID of the new category for the subject
-                example: 68081d3202a459c8915433c7
+                example: "68081d3202a459c8915433c7"
             additionalProperties: false
     responses:
       '200':
@@ -238,33 +238,33 @@ paths:
                 _id:
                   type: string
                   description: The unique identifier of the updated subject
-                  example: 680aba16c2b544ce98e8d35b
+                  example: "680aba16c2b544ce98e8d35b"
                 name:
                   type: string
                   description: The updated name of the subject
-                  example: Frontend
+                  example: "Frontend"
                 category:
                   type: object
                   properties:
                     _id:
                       type: string
                       description: The ID of the category
-                      example: 680aba16c2b544ce98e8d35b
+                      example: "680aba16c2b544ce98e8d35b"
                     name:
                       type: string
                       description: The name of the category
-                      example: IT
+                      example: "IT"
                     appearance:
                       type: object
                       properties:
                         icon:
                           type: string
                           description: The path to the category's icon
-                          example: icons/design.svg
+                          example: "icons/design.svg"
                         color:
                           type: string
                           description: The color of the category in HEX format
-                          example: #FF5733
+                          example: "#FF5733"
                 totalOffers:
                   type: object
                   properties:

--- a/docs/subject.yaml
+++ b/docs/subject.yaml
@@ -283,8 +283,18 @@ paths:
                   format: date-time
                   description: The time the subject was last updated
       '400':
-        description: Invalid subject or category ID format
+        description: |
+          Bad Request:
+          - Invalid subject or category ID format
+          - Name is required and must be a non-empty string
+          - Name must be between 2 and 50 characters
+          - No updates provided
       '404':
-        description: Subject or category not found
-      '500':
-        description: Internal server error
+        description: |
+          Not Found:
+          - Subject not found
+          - Category not found
+      '409':
+        description: |
+          Conflict:
+          - Subject with this name already exists

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -36,6 +36,10 @@ const updateSubject = async (req, res) => {
     return res.status(400).json({ message: 'Invalid subject ID format.' });
   }
 
+  if (!updates || Object.keys(updates).length === 0) {
+    return res.status(400).json({ message: 'No updates provided.' });
+  }
+
   const updatedSubject = await subjectService.updateSubject(id, updates);
 
   res.status(200).json(updatedSubject);

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -28,7 +28,21 @@ const getSubjectById = async (req, res) => {
   res.status(200).json(subject);
 };
 
+const updateSubject = async (req, res) => {
+  const { id } = req.params;
+  const updates = req.body;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'Invalid subject ID format.' });
+  }
+
+  const updatedSubject = await subjectService.updateSubject(id, updates);
+
+  res.status(200).json(updatedSubject);
+};
+
 module.exports = {
   getSubjects,
   getSubjectById,
+  updateSubject,
 };

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -18,4 +18,10 @@ router.get(
   asyncWrapper(subjectController.getSubjectById)
 );
 
+router.patch(
+  '/:id',
+  authMiddleware,
+  restrictTo('student'),
+  asyncWrapper(subjectController.updateSubject)
+);
 module.exports = router;

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -21,7 +21,7 @@ router.get(
 router.patch(
   '/:id',
   authMiddleware,
-  restrictTo('admin'),
+  restrictTo('student'),
   asyncWrapper(subjectController.updateSubject)
 );
 module.exports = router;

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -21,7 +21,7 @@ router.get(
 router.patch(
   '/:id',
   authMiddleware,
-  restrictTo('student'),
+  restrictTo('admin'),
   asyncWrapper(subjectController.updateSubject)
 );
 module.exports = router;

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -1,4 +1,5 @@
 const Subject = require('~/models/subject');
+const { validateCategoryOnUpdate } = require('~/validation/services/subject')
 
 const subjectService = {
   getSubjects: async ({ search = '', page = 1, limit = 20 } = {}) => {
@@ -43,6 +44,28 @@ const subjectService = {
     }
 
     return subject;
+  },
+
+  updateSubject: async (subjectId, updateData) => {
+    const subject = await Subject.findById(subjectId);
+
+    if (!subject) {
+      const error = new Error('Subject not found.');
+      error.status = 404;
+      throw error;
+    }
+
+    const validatedData = await validateCategoryOnUpdate(updateData);
+
+    const updatedSubject = await Subject.findByIdAndUpdate(subjectId, validatedData, {
+      new: true,
+      runValidators: true
+    })
+      .populate('category', 'name appearance')
+      .lean()
+      .exec();
+  
+    return updatedSubject;
   }
 };
 

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -55,7 +55,7 @@ const subjectService = {
       throw error;
     }
 
-    const validatedData = await validateCategoryOnUpdate(updateData);
+    const validatedData = await validateCategoryOnUpdate(subjectId, updateData);
 
     const updatedSubject = await Subject.findByIdAndUpdate(subjectId, validatedData, {
       new: true,

--- a/src/validation/services/subject.js
+++ b/src/validation/services/subject.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Category = require('~/models/category');
+const Subject = require('~/models/subject');
 const filterAllowedFields = require('~/utils/filterAllowedFields')
 
 
@@ -8,9 +9,35 @@ const allowedSubjectFieldsForUpdate = {
     category: true,
   }
 
-const validateCategoryOnUpdate = async (updateData) => {
+const validateCategoryOnUpdate = async (subjectId, updateData) => {
   const filteredUpdateData = filterAllowedFields(updateData, allowedSubjectFieldsForUpdate)
 
+  if (filteredUpdateData.name !== undefined) {
+    const name = filteredUpdateData.name;
+
+    if (typeof name !== 'string' || !name.trim()) {
+      const error = new Error('Name is required and must be a non-empty string.');
+      error.status = 400;
+      throw error;
+    }
+
+    if (name.trim().length < 2 || name.trim().length > 100) {
+      const error = new Error('Name must be between 2 and 100 characters.');
+      error.status = 400;
+      throw error;
+    }
+  }
+
+  const trimmedName = filteredUpdateData.name.trim();
+
+  const existingSubject = await Subject.findOne({ name: trimmedName, _id: { $ne: subjectId } }).lean();
+  
+  if (existingSubject) {
+    const error = new Error('Subject with this name already exists.');
+    error.status = 409;
+    throw error;
+  }
+  
   if (filteredUpdateData.category) {
     const categoryId = filteredUpdateData.category;
 
@@ -30,6 +57,7 @@ const validateCategoryOnUpdate = async (updateData) => {
 
   return filteredUpdateData
 }
+
 
 module.exports = {
   allowedSubjectFieldsForUpdate,

--- a/src/validation/services/subject.js
+++ b/src/validation/services/subject.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+const Category = require('~/models/category');
+const filterAllowedFields = require('~/utils/filterAllowedFields')
+
+
+const allowedSubjectFieldsForUpdate = {
+    name: true,
+    category: true,
+  }
+
+const validateCategoryOnUpdate = async (updateData) => {
+  const filteredUpdateData = filterAllowedFields(updateData, allowedSubjectFieldsForUpdate)
+
+  if (filteredUpdateData.category) {
+    const categoryId = filteredUpdateData.category;
+
+    if (!mongoose.Types.ObjectId.isValid(categoryId)) {
+      const error = new Error('Invalid category ID format.');
+      error.status = 400;
+      throw error;
+    }
+
+    const existingCategory = await Category.findById(categoryId).lean();
+    if (!existingCategory) {
+      const error = new Error('Category not found.');
+      error.status = 404;
+      throw error;
+    }
+  }
+
+  return filteredUpdateData
+}
+
+module.exports = {
+  allowedSubjectFieldsForUpdate,
+  validateCategoryOnUpdate
+}
+  


### PR DESCRIPTION
Add update subject endpoint and swagger docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a PATCH endpoint for students to update a subject's name and category.
- **Documentation**
  - Enhanced API docs with example values for subject details, categories, and offer counts.
- **Bug Fixes**
  - Strengthened validation to allow updates only to permitted fields and verify category existence before updating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->