### PR TITLE
#263 Updated nativeLanguage Field to Array in MongoDB Model

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -84,13 +84,17 @@ const userSchema = new Schema(
       }
     },
     nativeLanguage: {
-      type: String,
-      enum: {
-        values: SPOKEN_LANG_ENUM,
-        message: ENUM_CAN_BE_ONE_OF('native language', SPOKEN_LANG_ENUM)
+      type: [String],
+      validate: {
+        validator: function (langs) {
+          return (
+            Array.isArray(langs) && langs.every((lang) => SPOKEN_LANG_ENUM.includes(lang))
+          )
+        },
+        message: ENUM_CAN_BE_ONE_OF('native Language', SPOKEN_LANG_ENUM)
       },
-      default: "English"
-    },    
+      default: []
+    },
     isEmailConfirmed: {
       type: Boolean,
       default: false,


### PR DESCRIPTION
Changed the nativeLanguage field type from string to an array of strings (string[]) in the MongoDB schema. Updated all related validation logic to support multiple native languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now select multiple native languages instead of just one.

- **Bug Fixes**
  - Improved validation to ensure all selected native languages are supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->