### PR TITLE
Add delete subject endpoint

### DIFF
--- a/docs/subject.yaml
+++ b/docs/subject.yaml
@@ -180,6 +180,40 @@ paths:
           description: Category not found
         '409':
           description: Subject with this name already exists
+    delete:
+      tags:
+        - Subjects
+      summary: Delete a subject by ID
+      description: Deletes a subject identified by its unique ID.
+      operationId: deleteSubject
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: ID of the subject to delete.
+      responses:
+        '200':
+          description: Subject successfully deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Subject successfully deleted
+        '400':
+          description: Bad Request – Invalid ID supplied
+        '401':
+          description: Unauthorized – JWT token is missing or invalid
+        '403':
+          description: Forbidden – User doesn't have access
+        '404':
+          description: Not Found – Subject not found
   /subjects/{id}:
     get:
       tags:

--- a/src/controllers/subject.js
+++ b/src/controllers/subject.js
@@ -57,9 +57,22 @@ const updateSubject = async (req, res) => {
   res.status(200).json(updatedSubject);
 };
 
+const deleteSubject = async (req, res) => {
+  const { id } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'Invalid subject ID format.' });
+  }
+
+  await subjectService.deleteSubject(id);
+
+  res.status(200).json({ message: 'Subject successfully deleted.' });
+};
+
 module.exports = {
   getSubjects,
   getSubjectById,
   updateSubject,
   createSubject,
+  deleteSubject,
 };

--- a/src/routes/subject.js
+++ b/src/routes/subject.js
@@ -13,7 +13,7 @@ router.get(
 router.post(
   '/',
   authMiddleware,
-  restrictTo('student'), 
+  restrictTo('admin'), 
   asyncWrapper(subjectController.createSubject)
 );
 
@@ -27,7 +27,14 @@ router.get(
 router.patch(
   '/:id',
   authMiddleware,
-  restrictTo('student'),
+  restrictTo('admin'),
   asyncWrapper(subjectController.updateSubject)
+);
+
+router.delete(
+  '/:id',
+  authMiddleware,
+  restrictTo('admin'),
+  asyncWrapper(subjectController.deleteSubject)
 );
 module.exports = router;

--- a/src/services/subject.js
+++ b/src/services/subject.js
@@ -85,6 +85,18 @@ const subjectService = {
       .exec();
   
     return updatedSubject;
+  },
+
+  deleteSubject: async (subjectId) => {
+    const subject = await Subject.findById(subjectId);
+  
+    if (!subject) {
+      const error = new Error('Subject not found.');
+      error.status = 404;
+      throw error;
+    }
+  
+    await Subject.findByIdAndDelete(subjectId);
   }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for admins to delete a subject by its ID via the `/subjects/:id` endpoint.

- **Bug Fixes**
  - Updated access controls so that only admins can create, update, or delete subjects; students no longer have these permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->