### PR TITLE
Add getSubjectsByCategoryId endpoint

### DIFF
--- a/docs/category.yaml
+++ b/docs/category.yaml
@@ -384,3 +384,99 @@ paths:
         description: Forbidden – User doesn't have access
       '404':
         description: No categories found
+/categories/{id}/subjects:
+  get:
+    tags:
+      - Categories
+    summary: Get a paginated and filtered list of subjects by category ID
+    description: Returns a list of subjects for the given category ID with optional filtering by name and pagination.
+    operationId: getSubjectsByCategoryId
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: The ID of the category for which to retrieve subjects.
+      - name: search
+        in: query
+        required: false
+        schema:
+          type: string
+        description: Filter subjects name starting with this string.
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          minimum: 1
+        description: Page number for pagination.
+      - name: limit
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+        description: Number of categories per page.
+    responses:
+      '200':
+        description: A paginated list of subjects
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _id:
+                  type: string
+                  description: The unique identifier of the subject
+                  example: "680ab9772c70938761edda5e"
+                name:
+                  type: string
+                  description: The name of the subject
+                  example: "JavaScript"
+                category:
+                  type: object
+                  properties:
+                    _id:
+                      type: string
+                      description: The ID of the category
+                      example: "680ab9772c70938761edda5e"
+                    name:
+                      type: string
+                      description: The name of the category
+                      example: "IT"
+                    appearance:
+                      type: object
+                      properties:
+                        icon:
+                          type: string
+                          description: The path to the category's icon
+                          example: "icons/design.svg"
+                        color:
+                          type: string
+                          description: The color of the category in HEX format
+                          example: "#FF5733"
+                total:
+                  type: integer
+                  example: 57
+                page:
+                  type: integer
+                  example: 1
+                limit:
+                  type: integer
+                  example: 20
+                totalPages:
+                  type: integer
+                  example: 3
+      '401':
+        description: Unauthorized – JWT token is missing or invalid
+      '403':
+        description: Forbidden – User doesn't have access
+      '404':
+        description: No subjects found for this category
+      '400':
+        description: Invalid category ID format

--- a/src/controllers/category.js
+++ b/src/controllers/category.js
@@ -75,11 +75,32 @@ const createCategory = async (req, res) => {
   res.status(201).json(newCategory);
 };
 
+const getSubjectsByCategoryId = async (req, res) => {
+  const { id } = req.params;
+  const { search = '', page = 1, limit = 20 } = req.query;
+
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'Invalid category ID format.' });
+  }
+
+  const parsedPage = Math.max(1, parseInt(page, 10) || 1);
+  const parsedLimit = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+
+  const subjects = await categoryService.getSubjectsByCategoryId(id, {
+    search,
+    page: parsedPage,
+    limit: parsedLimit,
+  });
+
+  res.status(200).json(subjects);
+};
+
 
 module.exports = {
   getCategories,
   getSubjectNamesByCategoryId,
   getCategoryById,
   getCategoryNames,
-  createCategory
+  createCategory,
+  getSubjectsByCategoryId
 };

--- a/src/routes/category.js
+++ b/src/routes/category.js
@@ -34,4 +34,10 @@ router.get(
   restrictTo('student', 'tutor'), 
   asyncWrapper(categoryController.getCategoryById)
 );
+router.get(
+  '/:id/subjects',
+  authMiddleware,
+  restrictTo('student', 'tutor'),
+  asyncWrapper(categoryController.getSubjectsByCategoryId)
+);
 module.exports = router

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -126,7 +126,41 @@ const categoryService = {
       }
       throw err;
     }
-  }
+  },
+
+  getSubjectsByCategoryId: async (categoryId, { search = '', page = 1, limit = 20 } = {}) => {
+    const query = { category: categoryId };
+  
+    if (search) {
+      query.name = { $regex: `^${search}`, $options: 'i' };
+    }
+  
+    const skip = (page - 1) * limit;
+  
+    const [subjects, total] = await Promise.all([
+      Subject.find(query)
+        .skip(skip)
+        .limit(limit)
+        .lean()
+        .populate('category', 'name appearance')
+        .exec(),
+      Subject.countDocuments(query)
+    ]);
+
+    if (subjects.length === 0) {
+      const error = new Error('No subjects found for this category.');
+      error.status = 404;
+      throw error;
+    }
+  
+    return {
+      data: subjects,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit)
+    };
+  },
   
 };
 


### PR DESCRIPTION
Add getSubjectsByCategoryId endpoint and swagger docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new API endpoint to retrieve a paginated and filterable list of subjects for a specific category.
  - Added support for searching subjects by name prefix and customizable pagination options.
  - Responses include detailed subject and category information, along with pagination metadata.
  - Access to this endpoint is restricted to authenticated users with student or tutor roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->