### PR TITLE
Add total Offers for categories

### DIFF
--- a/docs/category.yaml
+++ b/docs/category.yaml
@@ -33,6 +33,9 @@ components:
               type: string
               example: "#66C42C"
               description: Color of the category icon. Defaults to '#66C42C'.
+        totalOffers:
+          type: integer
+          example: 10
         createdAt:
           type: string
           format: date-time

--- a/src/services/category.js
+++ b/src/services/category.js
@@ -16,8 +16,13 @@ const categoryService = {
       Category.countDocuments(query)
     ]);
 
+    const categoriesWithOffers = categories.map(category => ({
+      ...category,
+      totalOffers: 10
+    }));
+
     return {
-      data: categories,
+      data: categoriesWithOffers,
       total,
       page,
       limit,
@@ -68,7 +73,10 @@ const categoryService = {
       throw error;
     }
   
-    return category;
+    return {
+      ...category,
+      totalOffers: 10
+    };
   },
 
   getCategoryNames: async ({ search = '', page = 1, limit = 20 } = {}) => {


### PR DESCRIPTION
Add total Offers for categories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Category objects now include a new field, "totalOffers," which displays the total number of offers for each category. This value is currently set to 10 for all categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->