### PR TITLE
Change default offer query limit from 5 to 20

### DIFF
--- a/src/utils/offers/offerAggregateOptions.js
+++ b/src/utils/offers/offerAggregateOptions.js
@@ -18,7 +18,7 @@ const offerAggregateOptions = (query, params) => {
     sort = 'createdAt',
     status,
     skip = 0,
-    limit = 5
+    limit = 20
   } = query
 
   const match = {}


### PR DESCRIPTION
Before:
<img width="710" alt="Знімок екрана 2025-05-16 о 07 31 50" src="https://github.com/user-attachments/assets/9b856bc0-ca2e-4df7-8c3a-f1b9c48cb4b5" />
After:
<img width="709" alt="Знімок екрана 2025-05-16 о 07 31 27" src="https://github.com/user-attachments/assets/e8496095-8613-4619-824d-4d2dbc2b2149" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the default number of offer items displayed per page from 5 to 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->